### PR TITLE
Fix whole line matching behavior with possibly empty match

### DIFF
--- a/features/mivi-ex.feature
+++ b/features/mivi-ex.feature
@@ -199,6 +199,25 @@ Feature: Ex command
     zbzazz
     """
 
+  @bug
+  Scenario: substitute the whole lines with possibly empty match
+    Given the buffer is empty
+    When I insert:
+    """
+    foo
+    bar
+    baz
+    qux
+    """
+    And I type ":%s/.*/'\&'/"
+    Then I should see:
+    """
+    'foo'
+    'bar'
+    'baz'
+    'qux'
+    """
+
   Scenario: substitute the specified line range
     Given the buffer is empty
     When I insert:

--- a/mivi-common.el
+++ b/mivi-common.el
@@ -160,7 +160,7 @@ Return the number of occurrences."
                                      t))
       (when found
         (replace-match replace t)
-        (when (and empty-match (not (eobp)))
+        (when (and empty-match (not (eolp)))
           (forward-char 1))
         (setq last-replace-point (save-excursion
                                    (forward-line 0)


### PR DESCRIPTION
If possibly empty match matches with the whole line, the replacement was
happened in alternate lines.